### PR TITLE
Use new base for `curl` variant

### DIFF
--- a/curl/Dockerfile
+++ b/curl/Dockerfile
@@ -1,3 +1,3 @@
-FROM registry.gitlab.com/les-connecteurs/docker/alpine
+FROM ghcr.io/connecteurs/alpine
 
 RUN apk --no-cache add curl


### PR DESCRIPTION
This uses the new base image for the `curl` variant.